### PR TITLE
fix some bugs in endpoint create todo

### DIFF
--- a/src/main/java/jvm/pablohdz/todoapi/dto/TodoWithIdDto.java
+++ b/src/main/java/jvm/pablohdz/todoapi/dto/TodoWithIdDto.java
@@ -11,6 +11,27 @@ public class TodoWithIdDto
     private Date updatedAt;
     private String category;
 
+    public TodoWithIdDto()
+    {
+    }
+
+    public TodoWithIdDto(
+            Long id,
+            String name,
+            boolean status,
+            Date createdAt,
+            Date updatedAt,
+            String category
+    )
+    {
+        this.id = id;
+        this.name = name;
+        this.status = status;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.category = category;
+    }
+
     public Long getId()
     {
         return id;

--- a/src/main/java/jvm/pablohdz/todoapi/exceptions/DataAlreadyRegistered.java
+++ b/src/main/java/jvm/pablohdz/todoapi/exceptions/DataAlreadyRegistered.java
@@ -1,0 +1,9 @@
+package jvm.pablohdz.todoapi.exceptions;
+
+public class DataAlreadyRegistered extends RuntimeException
+{
+    public DataAlreadyRegistered(String message)
+    {
+        super(message);
+    }
+}

--- a/src/main/java/jvm/pablohdz/todoapi/service/TodoServiceImpl.java
+++ b/src/main/java/jvm/pablohdz/todoapi/service/TodoServiceImpl.java
@@ -18,6 +18,7 @@ import jvm.pablohdz.todoapi.dto.TodoRequestWithId;
 import jvm.pablohdz.todoapi.dto.TodoWithIdDto;
 import jvm.pablohdz.todoapi.entity.Todo;
 import jvm.pablohdz.todoapi.entity.UserAdmin;
+import jvm.pablohdz.todoapi.exceptions.DataAlreadyRegistered;
 import jvm.pablohdz.todoapi.exceptions.DataNotFoundException;
 import jvm.pablohdz.todoapi.mapper.TodoMapper;
 import jvm.pablohdz.todoapi.repository.TodoRepository;
@@ -54,8 +55,10 @@ public class TodoServiceImpl implements TodoService
     @Override
     public TodoWithIdDto createTodo(TodoRequest request)
     {
-        String username = utilsSecurityContext.getCurrentUsername();
         TodoRequest validatedRequest = validateDataRequest(request);
+        isAlreadyRegisteredTodo(request);
+
+        String username = utilsSecurityContext.getCurrentUsername();
         UserAdmin currentUser = isRegisteredUser(username);
 
         Todo todo = createTodo(validatedRequest, currentUser);
@@ -65,6 +68,14 @@ public class TodoServiceImpl implements TodoService
                 todo.getName() + " for the user: " + username);
 
         return todoMapper.todoToTodoWithIdDto(todoSaved);
+    }
+
+    private void isAlreadyRegisteredTodo(TodoRequest request)
+    {
+        Optional<Todo> optionalTodo = todoRepository.findByName(request.getName());
+        if (optionalTodo.isPresent())
+            throw new DataAlreadyRegistered("the todo with name: " + request.getName() +
+                    " already registered");
     }
 
     @Override

--- a/src/main/java/jvm/pablohdz/todoapi/service/UserAdminServiceExceptionHandler.java
+++ b/src/main/java/jvm/pablohdz/todoapi/service/UserAdminServiceExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
+import jvm.pablohdz.todoapi.exceptions.DataAlreadyRegistered;
 import jvm.pablohdz.todoapi.exceptions.DataNotFoundException;
 import jvm.pablohdz.todoapi.exceptions.DuplicateUserData;
 
@@ -31,6 +32,16 @@ public class UserAdminServiceExceptionHandler extends ResponseEntityExceptionHan
     {
         return handleExceptionInternal(exception, exception.getMessage(),
                 new HttpHeaders(), HttpStatus.NOT_FOUND, request
+        );
+    }
+
+    @ExceptionHandler(value = {DataAlreadyRegistered.class})
+    protected ResponseEntity<?> handleDataAlreadyRegistered(
+            DataAlreadyRegistered exception, WebRequest request
+    )
+    {
+        return handleExceptionInternal(exception, exception.getMessage(),
+                new HttpHeaders(), HttpStatus.BAD_REQUEST, request
         );
     }
 }


### PR DESCRIPTION
Create todo endpoint now verifies if the todo to save exists before trying to save in the database.

When Todo already registered a response send to a client a message with detail of errors
